### PR TITLE
Extract existing viz functionality

### DIFF
--- a/lib/bundler/dependency_graph.rb
+++ b/lib/bundler/dependency_graph.rb
@@ -1,2 +1,3 @@
 require "bundler/dependency_graph/version"
 require "bundler/dependency_graph/graph_builder"
+require "bundler/dependency_graph/graph"

--- a/lib/bundler/dependency_graph.rb
+++ b/lib/bundler/dependency_graph.rb
@@ -1,13 +1,2 @@
 require "bundler/dependency_graph/version"
-
-module Bundler
-  module DependencyGraph
-    class GraphBuilder
-      Bundler::Plugin::API.command "graph", self
-
-      def exec(command, args)
-        puts "Currently unimplented; use `bundle viz` to generate your graphs for now."
-      end
-    end
-  end
-end
+require "bundler/dependency_graph/graph_builder"

--- a/lib/bundler/dependency_graph/graph.rb
+++ b/lib/bundler/dependency_graph/graph.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+require "set"
+module Bundler
+  class Graph
+    GRAPH_NAME = :Gemfile
+
+    def initialize(env, output_file, show_version = false, show_requirements = false, output_format = "png", without = [])
+      @env               = env
+      @output_file       = output_file
+      @show_version      = show_version
+      @show_requirements = show_requirements
+      @output_format     = output_format
+      @without_groups    = without.map(&:to_sym)
+
+      @groups            = []
+      @relations         = Hash.new {|h, k| h[k] = Set.new }
+      @node_options      = {}
+      @edge_options      = {}
+
+      _populate_relations
+    end
+
+    attr_reader :groups, :relations, :node_options, :edge_options, :output_file, :output_format
+
+    def viz
+      GraphVizClient.new(self).run
+    end
+
+  private
+
+    def _populate_relations
+      parent_dependencies = _groups.values.to_set.flatten
+      loop do
+        break if parent_dependencies.empty?
+
+        tmp = Set.new
+        parent_dependencies.each do |dependency|
+          child_dependencies = spec_for_dependency(dependency).runtime_dependencies.to_set
+          @relations[dependency.name] += child_dependencies.map(&:name).to_set
+          tmp += child_dependencies
+
+          @node_options[dependency.name] = _make_label(dependency, :node)
+          child_dependencies.each do |c_dependency|
+            @edge_options["#{dependency.name}_#{c_dependency.name}"] = _make_label(c_dependency, :edge)
+          end
+        end
+        parent_dependencies = tmp
+      end
+    end
+
+    def _groups
+      relations = Hash.new {|h, k| h[k] = Set.new }
+      @env.current_dependencies.each do |dependency|
+        dependency.groups.each do |group|
+          next if @without_groups.include?(group)
+
+          relations[group.to_s].add(dependency)
+          @relations[group.to_s].add(dependency.name)
+
+          @node_options[group.to_s] ||= _make_label(group, :node)
+          @edge_options["#{group}_#{dependency.name}"] = _make_label(dependency, :edge)
+        end
+      end
+      @groups = relations.keys
+      relations
+    end
+
+    def _make_label(symbol_or_string_or_dependency, element_type)
+      case element_type.to_sym
+      when :node
+        if symbol_or_string_or_dependency.is_a?(Gem::Dependency)
+          label = symbol_or_string_or_dependency.name.dup
+          label << "\n#{spec_for_dependency(symbol_or_string_or_dependency).version}" if @show_version
+        else
+          label = symbol_or_string_or_dependency.to_s
+        end
+      when :edge
+        label = nil
+        if symbol_or_string_or_dependency.respond_to?(:requirements_list) && @show_requirements
+          tmp = symbol_or_string_or_dependency.requirements_list.join(", ")
+          label = tmp if tmp != ">= 0"
+        end
+      else
+        raise ArgumentError, "2nd argument is invalid"
+      end
+      label.nil? ? {} : { :label => label }
+    end
+
+    def spec_for_dependency(dependency)
+      @env.requested_specs.find {|s| s.name == dependency.name }
+    end
+
+    class GraphVizClient
+      def initialize(graph_instance)
+        @graph_name    = graph_instance.class::GRAPH_NAME
+        @groups        = graph_instance.groups
+        @relations     = graph_instance.relations
+        @node_options  = graph_instance.node_options
+        @edge_options  = graph_instance.edge_options
+        @output_file   = graph_instance.output_file
+        @output_format = graph_instance.output_format
+      end
+
+      def g
+        @g ||= ::GraphViz.digraph(@graph_name, :concentrate => true, :normalize => true, :nodesep => 0.55) do |g|
+          g.edge[:weight]   = 2
+          g.edge[:fontname] = g.node[:fontname] = "Arial, Helvetica, SansSerif"
+          g.edge[:fontsize] = 12
+        end
+      end
+
+      def run
+        @groups.each do |group|
+          g.add_nodes(
+            group, {
+              :style     => "filled",
+              :fillcolor => "#B9B9D5",
+              :shape     => "box3d",
+              :fontsize  => 16
+            }.merge(@node_options[group])
+          )
+        end
+
+        @relations.each do |parent, children|
+          children.each do |child|
+            if @groups.include?(parent)
+              g.add_nodes(child, { :style => "filled", :fillcolor => "#B9B9D5" }.merge(@node_options[child]))
+              g.add_edges(parent, child, { :constraint => false }.merge(@edge_options["#{parent}_#{child}"]))
+            else
+              g.add_nodes(child, @node_options[child])
+              g.add_edges(parent, child, @edge_options["#{parent}_#{child}"])
+            end
+          end
+        end
+
+        if @output_format.to_s == "debug"
+          $stdout.puts g.output :none => String
+          Bundler.ui.info "debugging bundle viz..."
+        else
+          begin
+            g.output @output_format.to_sym => "#{@output_file}.#{@output_format}"
+            Bundler.ui.info "#{@output_file}.#{@output_format}"
+          rescue ArgumentError => e
+            $stderr.puts "Unsupported output format. See Ruby-Graphviz/lib/graphviz/constants.rb"
+            raise e
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bundler/dependency_graph/graph.rb
+++ b/lib/bundler/dependency_graph/graph.rb
@@ -1,148 +1,150 @@
 # frozen_string_literal: true
 require "set"
 module Bundler
-  class Graph
-    GRAPH_NAME = :Gemfile
+  module DependencyGraph
+    class Graph
+      GRAPH_NAME = :Gemfile
 
-    def initialize(env, output_file, show_version = false, show_requirements = false, output_format = "png", without = [])
-      @env               = env
-      @output_file       = output_file
-      @show_version      = show_version
-      @show_requirements = show_requirements
-      @output_format     = output_format
-      @without_groups    = without.map(&:to_sym)
+      def initialize(env, output_file, show_version = false, show_requirements = false, output_format = "png", without = [])
+        @env               = env
+        @output_file       = output_file
+        @show_version      = show_version
+        @show_requirements = show_requirements
+        @output_format     = output_format
+        @without_groups    = without.map(&:to_sym)
 
-      @groups            = []
-      @relations         = Hash.new {|h, k| h[k] = Set.new }
-      @node_options      = {}
-      @edge_options      = {}
+        @groups            = []
+        @relations         = Hash.new {|h, k| h[k] = Set.new }
+        @node_options      = {}
+        @edge_options      = {}
 
-      _populate_relations
-    end
-
-    attr_reader :groups, :relations, :node_options, :edge_options, :output_file, :output_format
-
-    def viz
-      GraphVizClient.new(self).run
-    end
-
-  private
-
-    def _populate_relations
-      parent_dependencies = _groups.values.to_set.flatten
-      loop do
-        break if parent_dependencies.empty?
-
-        tmp = Set.new
-        parent_dependencies.each do |dependency|
-          child_dependencies = spec_for_dependency(dependency).runtime_dependencies.to_set
-          @relations[dependency.name] += child_dependencies.map(&:name).to_set
-          tmp += child_dependencies
-
-          @node_options[dependency.name] = _make_label(dependency, :node)
-          child_dependencies.each do |c_dependency|
-            @edge_options["#{dependency.name}_#{c_dependency.name}"] = _make_label(c_dependency, :edge)
-          end
-        end
-        parent_dependencies = tmp
-      end
-    end
-
-    def _groups
-      relations = Hash.new {|h, k| h[k] = Set.new }
-      @env.current_dependencies.each do |dependency|
-        dependency.groups.each do |group|
-          next if @without_groups.include?(group)
-
-          relations[group.to_s].add(dependency)
-          @relations[group.to_s].add(dependency.name)
-
-          @node_options[group.to_s] ||= _make_label(group, :node)
-          @edge_options["#{group}_#{dependency.name}"] = _make_label(dependency, :edge)
-        end
-      end
-      @groups = relations.keys
-      relations
-    end
-
-    def _make_label(symbol_or_string_or_dependency, element_type)
-      case element_type.to_sym
-      when :node
-        if symbol_or_string_or_dependency.is_a?(Gem::Dependency)
-          label = symbol_or_string_or_dependency.name.dup
-          label << "\n#{spec_for_dependency(symbol_or_string_or_dependency).version}" if @show_version
-        else
-          label = symbol_or_string_or_dependency.to_s
-        end
-      when :edge
-        label = nil
-        if symbol_or_string_or_dependency.respond_to?(:requirements_list) && @show_requirements
-          tmp = symbol_or_string_or_dependency.requirements_list.join(", ")
-          label = tmp if tmp != ">= 0"
-        end
-      else
-        raise ArgumentError, "2nd argument is invalid"
-      end
-      label.nil? ? {} : { :label => label }
-    end
-
-    def spec_for_dependency(dependency)
-      @env.requested_specs.find {|s| s.name == dependency.name }
-    end
-
-    class GraphVizClient
-      def initialize(graph_instance)
-        @graph_name    = graph_instance.class::GRAPH_NAME
-        @groups        = graph_instance.groups
-        @relations     = graph_instance.relations
-        @node_options  = graph_instance.node_options
-        @edge_options  = graph_instance.edge_options
-        @output_file   = graph_instance.output_file
-        @output_format = graph_instance.output_format
+        _populate_relations
       end
 
-      def g
-        @g ||= ::GraphViz.digraph(@graph_name, :concentrate => true, :normalize => true, :nodesep => 0.55) do |g|
-          g.edge[:weight]   = 2
-          g.edge[:fontname] = g.node[:fontname] = "Arial, Helvetica, SansSerif"
-          g.edge[:fontsize] = 12
-        end
+      attr_reader :groups, :relations, :node_options, :edge_options, :output_file, :output_format
+
+      def viz
+        GraphVizClient.new(self).run
       end
 
-      def run
-        @groups.each do |group|
-          g.add_nodes(
-            group, {
-              :style     => "filled",
-              :fillcolor => "#B9B9D5",
-              :shape     => "box3d",
-              :fontsize  => 16
-            }.merge(@node_options[group])
-          )
-        end
+    private
 
-        @relations.each do |parent, children|
-          children.each do |child|
-            if @groups.include?(parent)
-              g.add_nodes(child, { :style => "filled", :fillcolor => "#B9B9D5" }.merge(@node_options[child]))
-              g.add_edges(parent, child, { :constraint => false }.merge(@edge_options["#{parent}_#{child}"]))
-            else
-              g.add_nodes(child, @node_options[child])
-              g.add_edges(parent, child, @edge_options["#{parent}_#{child}"])
+      def _populate_relations
+        parent_dependencies = _groups.values.to_set.flatten
+        loop do
+          break if parent_dependencies.empty?
+
+          tmp = Set.new
+          parent_dependencies.each do |dependency|
+            child_dependencies = spec_for_dependency(dependency).runtime_dependencies.to_set
+            @relations[dependency.name] += child_dependencies.map(&:name).to_set
+            tmp += child_dependencies
+
+            @node_options[dependency.name] = _make_label(dependency, :node)
+            child_dependencies.each do |c_dependency|
+              @edge_options["#{dependency.name}_#{c_dependency.name}"] = _make_label(c_dependency, :edge)
             end
           end
+          parent_dependencies = tmp
+        end
+      end
+
+      def _groups
+        relations = Hash.new {|h, k| h[k] = Set.new }
+        @env.current_dependencies.each do |dependency|
+          dependency.groups.each do |group|
+            next if @without_groups.include?(group)
+
+            relations[group.to_s].add(dependency)
+            @relations[group.to_s].add(dependency.name)
+
+            @node_options[group.to_s] ||= _make_label(group, :node)
+            @edge_options["#{group}_#{dependency.name}"] = _make_label(dependency, :edge)
+          end
+        end
+        @groups = relations.keys
+        relations
+      end
+
+      def _make_label(symbol_or_string_or_dependency, element_type)
+        case element_type.to_sym
+        when :node
+          if symbol_or_string_or_dependency.is_a?(Gem::Dependency)
+            label = symbol_or_string_or_dependency.name.dup
+            label << "\n#{spec_for_dependency(symbol_or_string_or_dependency).version}" if @show_version
+          else
+            label = symbol_or_string_or_dependency.to_s
+          end
+        when :edge
+          label = nil
+          if symbol_or_string_or_dependency.respond_to?(:requirements_list) && @show_requirements
+            tmp = symbol_or_string_or_dependency.requirements_list.join(", ")
+            label = tmp if tmp != ">= 0"
+          end
+        else
+          raise ArgumentError, "2nd argument is invalid"
+        end
+        label.nil? ? {} : { :label => label }
+      end
+
+      def spec_for_dependency(dependency)
+        @env.requested_specs.find {|s| s.name == dependency.name }
+      end
+
+      class GraphVizClient
+        def initialize(graph_instance)
+          @graph_name    = graph_instance.class::GRAPH_NAME
+          @groups        = graph_instance.groups
+          @relations     = graph_instance.relations
+          @node_options  = graph_instance.node_options
+          @edge_options  = graph_instance.edge_options
+          @output_file   = graph_instance.output_file
+          @output_format = graph_instance.output_format
         end
 
-        if @output_format.to_s == "debug"
-          $stdout.puts g.output :none => String
-          Bundler.ui.info "debugging bundle viz..."
-        else
-          begin
-            g.output @output_format.to_sym => "#{@output_file}.#{@output_format}"
-            Bundler.ui.info "#{@output_file}.#{@output_format}"
-          rescue ArgumentError => e
-            $stderr.puts "Unsupported output format. See Ruby-Graphviz/lib/graphviz/constants.rb"
-            raise e
+        def g
+          @g ||= ::GraphViz.digraph(@graph_name, :concentrate => true, :normalize => true, :nodesep => 0.55) do |g|
+            g.edge[:weight]   = 2
+            g.edge[:fontname] = g.node[:fontname] = "Arial, Helvetica, SansSerif"
+            g.edge[:fontsize] = 12
+          end
+        end
+
+        def run
+          @groups.each do |group|
+            g.add_nodes(
+              group, {
+                :style     => "filled",
+                :fillcolor => "#B9B9D5",
+                :shape     => "box3d",
+                :fontsize  => 16
+              }.merge(@node_options[group])
+            )
+          end
+
+          @relations.each do |parent, children|
+            children.each do |child|
+              if @groups.include?(parent)
+                g.add_nodes(child, { :style => "filled", :fillcolor => "#B9B9D5" }.merge(@node_options[child]))
+                g.add_edges(parent, child, { :constraint => false }.merge(@edge_options["#{parent}_#{child}"]))
+              else
+                g.add_nodes(child, @node_options[child])
+                g.add_edges(parent, child, @edge_options["#{parent}_#{child}"])
+              end
+            end
+          end
+
+          if @output_format.to_s == "debug"
+            $stdout.puts g.output :none => String
+            Bundler.ui.info "debugging bundle viz..."
+          else
+            begin
+              g.output @output_format.to_sym => "#{@output_file}.#{@output_format}"
+              Bundler.ui.info "#{@output_file}.#{@output_format}"
+            rescue ArgumentError => e
+              $stderr.puts "Unsupported output format. See Ruby-Graphviz/lib/graphviz/constants.rb"
+              raise e
+            end
           end
         end
       end

--- a/lib/bundler/dependency_graph/graph_builder.rb
+++ b/lib/bundler/dependency_graph/graph_builder.rb
@@ -1,0 +1,11 @@
+module Bundler
+  module DependencyGraph
+    class GraphBuilder
+      Bundler::Plugin::API.command "graph", self
+
+      def exec(command, args)
+        puts "Currently unimplented; use `bundle viz` to generate your graphs for now."
+      end
+    end
+  end
+end

--- a/lib/bundler/dependency_graph/graph_builder.rb
+++ b/lib/bundler/dependency_graph/graph_builder.rb
@@ -12,16 +12,17 @@ module Bundler
         #   are handled by Thor, but we're not entirely sure how the
         #   Bundler::Plugin::API passes them (or doesn't) to plugins
 
-        args[:file]         = "gem_graph"
-        args[:format]       = "png"
-        args[:requirements] = false
-        args[:version]      = false
-        args[:without]      = []
+        options = {}
+        options[:file]         = "gem_graph"
+        options[:format]       = "png"
+        options[:requirements] = false
+        options[:version]      = false
+        options[:without]      = []
 
-        args[:without] = args[:without].join(":").tr(" ", ":").split(":")
-        output_file = File.expand_path(args[:file])
+        options[:without] = options[:without].join(":").tr(" ", ":").split(":")
+        output_file = File.expand_path(options[:file])
 
-        graph = Graph.new(Bundler.load, output_file, args[:version], args[:requirements], args[:format], args[:without])
+        graph = Graph.new(Bundler.load, output_file, options[:version], options[:requirements], options[:format], options[:without])
         graph.viz
       rescue LoadError => e
         Bundler.ui.error e.inspect

--- a/lib/bundler/dependency_graph/graph_builder.rb
+++ b/lib/bundler/dependency_graph/graph_builder.rb
@@ -5,6 +5,32 @@ module Bundler
 
       def exec(command, args)
         puts "Currently unimplented; use `bundle viz` to generate your graphs for now."
+
+        require "graphviz"
+
+        # Temporarily assign default values to incoming args. In Bundler, these
+        #   are handled by Thor, but we're not entirely sure how the
+        #   Bundler::Plugin::API passes them (or doesn't) to plugins
+
+        args[:file]         = "gem_graph"
+        args[:format]       = "png"
+        args[:requirements] = false
+        args[:version]      = false
+        args[:without]      = []
+
+        args[:without] = args[:without].join(":").tr(" ", ":").split(":")
+        output_file = File.expand_path(args[:file])
+
+        graph = Graph.new(Bundler.load, output_file, args[:version], args[:requirements], args[:format], args[:without])
+        graph.viz
+      rescue LoadError => e
+        Bundler.ui.error e.inspect
+        Bundler.ui.warn "Make sure you have the graphviz ruby gem. You can install it with:"
+        Bundler.ui.warn "`gem install ruby-graphviz`"
+      rescue StandardError => e
+        raise unless e.message =~ /GraphViz not installed or dot not in PATH/
+        Bundler.ui.error e.message
+        Bundler.ui.warn "Please install GraphViz. On a Mac with Homebrew, you can run `brew install graphviz`."
       end
     end
   end


### PR DESCRIPTION
This is a direct extraction of the code behind `bundle viz`. 

TODO:
+ there are only integration tests for `viz` and they're in rspec, so those need to get ported over somehow
+ we don't currently respect any CLI flags or options, instead spoofing in defaults from the Thor implementation in bundler/bundler


This is an MVP for a 0.1.0 release, as it works! It works!

Paired with @roseaboveit